### PR TITLE
feat: Implemented publish command

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
     preset: 'ts-jest',
+    setupFilesAfterEnv: ['./test/setupTests.ts'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
+                "axios": "^0.21.1",
                 "yargs": "^15.4.1"
             },
             "bin": {
@@ -16,9 +17,12 @@
             },
             "devDependencies": {
                 "@types/jest": "^26.0.20",
+                "@types/mock-fs": "^4.13.0",
                 "@types/yargs": "^15.0.13",
+                "factory.ts": "^0.5.1",
                 "husky": "^4.3.8",
                 "jest": "^26.6.3",
+                "mock-fs": "^4.13.0",
                 "prettier": "^2.2.1",
                 "pretty-quick": "^3.1.0",
                 "ts-jest": "^26.5.2",
@@ -919,6 +923,15 @@
             "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
             "dev": true
         },
+        "node_modules/@types/mock-fs": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.0.tgz",
+            "integrity": "sha512-FUqxhURwqFtFBCuUj3uQMp7rPSQs//b3O9XecAVxhqS9y4/W8SIJEZFq2mmpnFVZBXwR/2OyPLE97CpyYiB8Mw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/node": {
             "version": "14.14.31",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
@@ -1188,6 +1201,14 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
+        },
+        "node_modules/axios": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+            "dependencies": {
+                "follow-redirects": "^1.10.0"
+            }
         },
         "node_modules/babel-jest": {
             "version": "26.6.3",
@@ -1605,6 +1626,20 @@
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^6.2.0"
+            }
+        },
+        "node_modules/clone-deep": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+            "dev": true,
+            "dependencies": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/co": {
@@ -2289,6 +2324,19 @@
                 "node >=0.6.0"
             ]
         },
+        "node_modules/factory.ts": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/factory.ts/-/factory.ts-0.5.1.tgz",
+            "integrity": "sha512-jwAq8w7MmxUojIFzKezMwTzDc5QoxcqzAA8+n9A0EAWBje2CRHUeBrW9x/ioV2DRjHgkHX7i0G0ipfDhlatIQw==",
+            "dev": true,
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "source-map-support": "^0.5.9"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2353,6 +2401,25 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+            "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
             }
         },
         "node_modules/for-in": {
@@ -4232,6 +4299,12 @@
                 "node": ">=10"
             }
         },
+        "node_modules/mock-fs": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
+            "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==",
+            "dev": true
+        },
         "node_modules/mri": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
@@ -5507,6 +5580,18 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/shallow-clone": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+            "dev": true,
+            "dependencies": {
+                "kind-of": "^6.0.2"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/shebang-command": {
@@ -7517,6 +7602,15 @@
             "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
             "dev": true
         },
+        "@types/mock-fs": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.0.tgz",
+            "integrity": "sha512-FUqxhURwqFtFBCuUj3uQMp7rPSQs//b3O9XecAVxhqS9y4/W8SIJEZFq2mmpnFVZBXwR/2OyPLE97CpyYiB8Mw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/node": {
             "version": "14.14.31",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
@@ -7729,6 +7823,14 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
+        },
+        "axios": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+            "requires": {
+                "follow-redirects": "^1.10.0"
+            }
         },
         "babel-jest": {
             "version": "26.6.3",
@@ -8081,6 +8183,17 @@
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^6.2.0"
+            }
+        },
+        "clone-deep": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
             }
         },
         "co": {
@@ -8630,6 +8743,16 @@
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
             "dev": true
         },
+        "factory.ts": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/factory.ts/-/factory.ts-0.5.1.tgz",
+            "integrity": "sha512-jwAq8w7MmxUojIFzKezMwTzDc5QoxcqzAA8+n9A0EAWBje2CRHUeBrW9x/ioV2DRjHgkHX7i0G0ipfDhlatIQw==",
+            "dev": true,
+            "requires": {
+                "clone-deep": "^4.0.1",
+                "source-map-support": "^0.5.9"
+            }
+        },
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8683,6 +8806,11 @@
             "requires": {
                 "semver-regex": "^3.1.2"
             }
+        },
+        "follow-redirects": {
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+            "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
         },
         "for-in": {
             "version": "1.0.2",
@@ -10171,6 +10299,12 @@
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
             "dev": true
         },
+        "mock-fs": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
+            "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==",
+            "dev": true
+        },
         "mri": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
@@ -11187,6 +11321,15 @@
                     "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
                     "dev": true
                 }
+            }
+        },
+        "shallow-clone": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^6.0.2"
             }
         },
         "shebang-command": {

--- a/package.json
+++ b/package.json
@@ -31,9 +31,12 @@
     "homepage": "https://github.com/HLTech/judge-d-js",
     "devDependencies": {
         "@types/jest": "^26.0.20",
+        "@types/mock-fs": "^4.13.0",
         "@types/yargs": "^15.0.13",
+        "factory.ts": "^0.5.1",
         "husky": "^4.3.8",
         "jest": "^26.6.3",
+        "mock-fs": "^4.13.0",
         "prettier": "^2.2.1",
         "pretty-quick": "^3.1.0",
         "ts-jest": "^26.5.2",
@@ -44,6 +47,7 @@
         "tag": "latest"
     },
     "dependencies": {
+        "axios": "^0.21.1",
         "yargs": "^15.4.1"
     }
 }

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -1,0 +1,15 @@
+import { generateContractsForm } from '../utils/generate-contracts-form';
+import { CliArguments } from '../utils/define-args';
+import { readPacts } from '../utils/read-pacts';
+import { buildUrl } from '../utils/build-url';
+import { postPacts } from '../utils/post-pacts';
+
+export async function publish(argv: CliArguments) {
+    const { pactsDir, serviceName, url, serviceVersion } = argv;
+
+    const pacts = readPacts(pactsDir);
+    const contractsForm = generateContractsForm(pacts);
+    const judgeDUrl = buildUrl(url, serviceName, serviceVersion);
+
+    await postPacts(judgeDUrl, contractsForm);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,14 @@
 import { defineArgs } from './utils/define-args';
+import { publish } from './commands/publish';
 
-export function run(process: NodeJS.Process) {
+export async function run(process: NodeJS.Process) {
     const argv = defineArgs(process.argv.slice(2));
-    console.log(argv);
+
+    if (argv._.includes('publish')) {
+        try {
+            await publish(argv);
+        } catch (e) {
+            process.exit(1);
+        }
+    }
 }

--- a/src/utils/build-url.ts
+++ b/src/utils/build-url.ts
@@ -1,0 +1,7 @@
+export function buildUrl(
+    url: string,
+    serviceName: string,
+    serviceVersion: string
+) {
+    return `${url}/contracts/services/${serviceName}/versions/${serviceVersion}`;
+}

--- a/src/utils/define-args.ts
+++ b/src/utils/define-args.ts
@@ -1,13 +1,13 @@
 import yargs from 'yargs';
 
-interface CliArguments {
+export interface CliArguments {
     url: string;
     pactsDir: string;
     serviceName: string;
     serviceVersion: string;
 }
 
-export function defineArgs(cliArgs: string[]): CliArguments {
+export function defineArgs(cliArgs: string[]): yargs.Arguments<CliArguments> {
     return yargs(cliArgs)
         .command<CliArguments>('publish', 'Publish contracts', (yargs) => {
             yargs.options({

--- a/src/utils/generate-contracts-form.ts
+++ b/src/utils/generate-contracts-form.ts
@@ -1,0 +1,39 @@
+import { Pact } from './read-pacts';
+
+export function generateContractsForm(pactFiles: Pact[]): ServiceContractsForm {
+    return pactFiles.reduce<ServiceContractsForm>(
+        (serviceContractsForm, fileContent) => {
+            if (fileContent.provider?.name) {
+                return {
+                    ...serviceContractsForm,
+                    expectations: {
+                        ...serviceContractsForm.expectations,
+                        [fileContent.provider.name]: {
+                            rest: {
+                                value: JSON.stringify(fileContent),
+                                mimeType: 'application-json',
+                            },
+                        },
+                    },
+                };
+            }
+            return serviceContractsForm;
+        },
+        {
+            capabilities: {},
+            expectations: {},
+        }
+    );
+}
+
+export interface ServiceContractsForm {
+    capabilities: Record<string, RestContract>;
+    expectations: Record<string, RestContract>;
+}
+
+interface RestContract {
+    rest: {
+        value: string;
+        mimeType: 'application-json';
+    };
+}

--- a/src/utils/post-pacts.ts
+++ b/src/utils/post-pacts.ts
@@ -1,0 +1,6 @@
+import { ServiceContractsForm } from './generate-contracts-form';
+import axios from 'axios';
+
+export function postPacts(url: string, pacts: ServiceContractsForm) {
+    return axios.post(url, pacts);
+}

--- a/src/utils/read-pacts.ts
+++ b/src/utils/read-pacts.ts
@@ -1,0 +1,14 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function readPacts(dir: string): Pact[] {
+    return fs.readdirSync(dir).map((fileName) => {
+        const filePath = path.join(dir, fileName);
+        return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    });
+}
+
+export interface Pact {
+    provider?: { name?: string };
+    [x: string]: any;
+}

--- a/test/generate-contracts-form.test.ts
+++ b/test/generate-contracts-form.test.ts
@@ -1,0 +1,34 @@
+import { pactMockFactory } from './mocks/pact.mock';
+import { generateContractsForm } from '../src/utils/generate-contracts-form';
+
+describe('generateContractsForm', () => {
+    test('returns correct ServiceContractsForm', () => {
+        const pactMockForProviderService1 = pactMockFactory.build();
+        const pactMockForProviderService2 = pactMockFactory.build({
+            provider: { name: 'provider-service-2' },
+        });
+
+        const serviceContractsForm = generateContractsForm([
+            pactMockForProviderService1,
+            pactMockForProviderService2,
+        ]);
+
+        expect(serviceContractsForm).toEqual({
+            capabilities: {},
+            expectations: {
+                [pactMockForProviderService1.provider.name]: {
+                    rest: {
+                        value: JSON.stringify(pactMockForProviderService1),
+                        mimeType: 'application-json',
+                    },
+                },
+                [pactMockForProviderService2.provider.name]: {
+                    rest: {
+                        value: JSON.stringify(pactMockForProviderService2),
+                        mimeType: 'application-json',
+                    },
+                },
+            },
+        });
+    });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,0 @@
-describe('tests', () => {
-    test('it works', () => {
-        expect(1 + 1).toEqual(2);
-    });
-});

--- a/test/mocks/pact.mock.ts
+++ b/test/mocks/pact.mock.ts
@@ -1,0 +1,34 @@
+import { makeFactory } from 'factory.ts';
+
+export const pactMockFactory = makeFactory({
+    provider: {
+        name: 'provider-service-1',
+    },
+    consumer: {
+        name: 'consumer-service-1',
+    },
+    interactions: [
+        {
+            description: 'publish request 200 response',
+            request: {
+                method: 'PUT',
+                path: 'environments/testing-environment',
+                headers: {},
+                query: '',
+                body: [
+                    {
+                        id: '1',
+                        name: 'John Doe',
+                    },
+                ],
+            },
+            response: {
+                status: '200',
+                headers: {},
+            },
+        },
+    ],
+    metadata: {
+        pactSpecificationVersion: '1.0.0',
+    },
+});

--- a/test/mocks/serviceContractsForm.mock.ts
+++ b/test/mocks/serviceContractsForm.mock.ts
@@ -1,0 +1,17 @@
+import { makeFactory } from 'factory.ts';
+import { ServiceContractsForm } from '../../src/utils/generate-contracts-form';
+import { pactMockFactory } from './pact.mock';
+
+export const serviceContractsFormMockFactory = makeFactory<ServiceContractsForm>(
+    {
+        capabilities: {},
+        expectations: {
+            'provider-service-1': {
+                rest: {
+                    value: JSON.stringify(pactMockFactory.build()),
+                    mimeType: 'application-json',
+                },
+            },
+        },
+    }
+);

--- a/test/post-pacts.test.ts
+++ b/test/post-pacts.test.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+import { serviceContractsFormMockFactory } from './mocks/serviceContractsForm.mock';
+import { postPacts } from '../src/utils/post-pacts';
+
+jest.mock('axios');
+
+describe('postPacts', () => {
+    test('calls API with correct url and data passed as arguments', () => {
+        const serviceContractsFormMock = serviceContractsFormMockFactory.build();
+        const judgeDUrl = 'http://judge-d.instance.com';
+        postPacts(judgeDUrl, serviceContractsFormMock);
+
+        expect(axios.post).toHaveBeenCalledTimes(1);
+        expect(axios.post).toHaveBeenCalledWith(
+            judgeDUrl,
+            serviceContractsFormMock
+        );
+    });
+});

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -1,0 +1,63 @@
+import axios from 'axios';
+import { pactMockFactory } from './mocks/pact.mock';
+import mockFs from 'mock-fs';
+import { publish } from '../src/commands/publish';
+import { buildUrl } from '../src/utils/build-url';
+import { serviceContractsFormMockFactory } from './mocks/serviceContractsForm.mock';
+
+jest.mock('axios');
+
+describe('publish', () => {
+    test('read pact files, generate contracts form and makes post call to judge-d API', async () => {
+        const pactMockForProviderService1 = pactMockFactory.build();
+        const pactMockForProviderService2 = pactMockFactory.build({
+            provider: { name: 'provider-service-2' },
+        });
+
+        mockFs({
+            './pacts': {
+                'service-1-pact.json': JSON.stringify(
+                    pactMockForProviderService1
+                ),
+                'service-2-pact.json': JSON.stringify(
+                    pactMockForProviderService2
+                ),
+            },
+        });
+
+        const serviceContractsFormMock = serviceContractsFormMockFactory.build({
+            expectations: {
+                [pactMockForProviderService1.provider.name]: {
+                    rest: {
+                        value: JSON.stringify(pactMockForProviderService1),
+                        mimeType: 'application-json',
+                    },
+                },
+                [pactMockForProviderService2.provider.name]: {
+                    rest: {
+                        value: JSON.stringify(pactMockForProviderService2),
+                        mimeType: 'application-json',
+                    },
+                },
+            },
+        });
+
+        const serviceName = 'example-service';
+        const serviceVersion = '1.1.0';
+        const url = 'http://judge-d.instance.com';
+        const pactsPostUrl = buildUrl(url, serviceName, serviceVersion);
+
+        await publish({
+            url,
+            serviceVersion,
+            serviceName,
+            pactsDir: './pacts',
+        });
+
+        expect(axios.post).toHaveBeenCalledTimes(1);
+        expect(axios.post).toHaveBeenCalledWith(
+            pactsPostUrl,
+            serviceContractsFormMock
+        );
+    });
+});

--- a/test/read-pacts.test.ts
+++ b/test/read-pacts.test.ts
@@ -1,0 +1,23 @@
+import { readPacts } from '../src/utils/read-pacts';
+import { pactMockFactory } from './mocks/pact.mock';
+import mockFs from 'mock-fs';
+
+describe('readPacts', () => {
+    test('returns correctly read pact files', () => {
+        const service1PactMock = pactMockFactory.build();
+        const service2PactMock = pactMockFactory.build({
+            provider: { name: 'provider-service-2' },
+        });
+
+        mockFs({
+            './pacts': {
+                'service-1-pact.json': JSON.stringify(service1PactMock),
+                'service-2-pact.json': JSON.stringify(service2PactMock),
+            },
+        });
+
+        const pacts = readPacts('./pacts');
+
+        expect(pacts).toEqual([service1PactMock, service2PactMock]);
+    });
+});

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,0 +1,36 @@
+import { run } from '../src';
+import { publish } from '../src/commands/publish';
+
+jest.mock('../src/commands/publish');
+
+describe('run', () => {
+    test('it invokes publish function with correct arguments', () => {
+        const processMock = {
+            argv: [
+                'node-param',
+                'node-param',
+                'publish',
+                '--url',
+                'judge-d.instance.com',
+                '--pactsDir',
+                '/pacts',
+                '--serviceName',
+                'example-service',
+                '--serviceVersion',
+                '1.0.0',
+            ],
+        } as NodeJS.Process;
+
+        run(processMock);
+
+        expect(publish).toHaveBeenCalledWith(
+            expect.objectContaining({
+                _: ['publish'],
+                pactsDir: '/pacts',
+                url: 'judge-d.instance.com',
+                serviceName: 'example-service',
+                serviceVersion: '1.0.0',
+            })
+        );
+    });
+});

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -1,0 +1,3 @@
+import mockFs from 'mock-fs';
+
+afterAll(() => mockFs.restore());

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "esModuleInterop": true
+    },
+    "include": ["./**/*"]
+}


### PR DESCRIPTION
Publish command implementation:

1. Read pact json files from directory passed with --pactsDir
2. Use pacts from previous step and generate ServiceContractsForm object which is accepted by judge-d API
3. Build url for posting form using --url, --serviceName and --serviceVersion values.
4. Post form to judge-d.

