### PR TITLE
feat: Argument outFile takes an extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ $ judge-d verify --help
 ```
 
 ```
-Verify contracts
+It verifies contracts and generates HTML report if outFile is provided
 
 Options:
   --url             Url to judge-d instance                  [string] [required]
   --serviceName     Service name                             [string] [required]
   --serviceVersion  Service version                          [string] [required]
   --environment     Environment name                         [string] [required]
-  --outFile         Path with HTML report filename                      [string]
+  --outFile         Path with HTML report filename, ex. report.html     [string]
 
 ```

--- a/src/utils/define-args.ts
+++ b/src/utils/define-args.ts
@@ -61,7 +61,7 @@ export function defineArgs(
                 },
                 outFile: {
                     type: 'string',
-                    describe: 'Path with HTML report filename',
+                    describe: 'Path with HTML report filename, ex. report.html',
                 },
             });
         })

--- a/src/utils/write-report.ts
+++ b/src/utils/write-report.ts
@@ -6,5 +6,5 @@ export function writeReport(outFile: string, htmlReport: string) {
     if (!fs.existsSync(pathToReportDir)) {
         fs.mkdirSync(pathToReportDir, { recursive: true });
     }
-    fs.writeFileSync(`${outFile}.html`, htmlReport);
+    fs.writeFileSync(outFile, htmlReport);
 }

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -68,6 +68,7 @@ describe('run', () => {
         mocked(axios.get).mockResolvedValueOnce({
             data: validationResultsMock,
         });
+        mocked(ejs.renderFile).mockResolvedValueOnce('report content');
 
         const processMock = processMockFactory.build({
             argv: [
@@ -83,7 +84,7 @@ describe('run', () => {
                 '--environment',
                 'DEMO',
                 '--outFile',
-                './report/dredd/contract-tests-report',
+                './report/dredd/contract-tests-report.html',
             ],
         });
 
@@ -104,6 +105,10 @@ describe('run', () => {
         expect(ejs.renderFile).toHaveBeenCalledWith(pathToTemplate, {
             validationResults: validationResultsMock,
         });
+        expect(fs.writeFileSync).toHaveBeenCalledWith(
+            './report/dredd/contract-tests-report.html',
+            'report content'
+        );
         expect(processMock.exit).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Previously outFile was set without extension, ex. ./report/contract-test-report and .html was added automatically.

Now file is saved with exact name passed through outFile, ./report/contract-test-report.html creates contract-test-report.html.